### PR TITLE
fix: 子供が生成されなかった場合の処理を追加し、適応度の条件を修正

### DIFF
--- a/src/fast_eax/generational_model.hpp
+++ b/src/fast_eax/generational_model.hpp
@@ -58,6 +58,11 @@ namespace eax {
                     Individual& parent_A = population[parent_A_index];
                     Individual& parent_B = population[parent_B_index];
                     std::vector<Child> children = cross_over(parent_A, parent_B, N_cross, env, rng);
+
+                    if (children.empty()) {
+                        continue; // 子供が生成されなかった場合はスキップ
+                    }
+
                     std::vector<double> children_fitness = calc_all_fitness(children, env);
                     
                     // 子供の中で最良の個体を選択
@@ -70,7 +75,7 @@ namespace eax {
                         }
                     }
                     
-                    if (best_fitness != 0.0) {
+                    if (best_fitness > 0.0) {
                         // 子供の適応度が0でない場合、親Aを子供に置き換える
                         parent_A = std::move(children[best_index]);
                     } else {


### PR DESCRIPTION
This pull request introduces improvements to the generational model in `src/fast_eax/generational_model.hpp` to enhance robustness and correctness. The most important changes include adding a check to skip empty child populations and refining the fitness condition for replacing parents with children.

### Enhancements to robustness:

* Added a check to skip processing when no children are generated during the crossover step, preventing potential errors or unnecessary computations. (`src/fast_eax/generational_model.hpp`, [src/fast_eax/generational_model.hppR61-R65](diffhunk://#diff-fe804a455710a3bdcd771dd4b1f24d9850c83990f9f9d57a8d592b9b8788b0e3R61-R65))

### Refinements to fitness evaluation:

* Updated the fitness condition to replace parents only when the best fitness of the children is strictly greater than 0.0, ensuring correctness in the replacement logic. (`src/fast_eax/generational_model.hpp`, [src/fast_eax/generational_model.hppL73-R78](diffhunk://#diff-fe804a455710a3bdcd771dd4b1f24d9850c83990f9f9d57a8d592b9b8788b0e3L73-R78))