### PR TITLE
fix: <functional>ヘッダーをobject_pool.hppに追加

### DIFF
--- a/src/libmpilib/object_pool.hpp
+++ b/src/libmpilib/object_pool.hpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <vector>
+#include <functional>
 
 namespace mpi {
     template <typename T>


### PR DESCRIPTION
This pull request makes a small change to the `src/libmpilib/object_pool.hpp` file by adding the `<functional>` header to enable the use of standard function-related utilities.