### PR TITLE
中間個体のリセット処理を修正

### DIFF
--- a/src/fast_eax/eax.cpp
+++ b/src/fast_eax/eax.cpp
@@ -148,7 +148,7 @@ namespace eax {
 eax::Child IntermediateIndividual::convert_to_child_and_revert() {
     revert();
     eax::Child child(std::move(modifications));
-    modifications.clear();
+    reset();
     return child;
 }
 


### PR DESCRIPTION
This pull request makes a minor change to the `IntermediateIndividual::convert_to_child_and_revert()` method in `src/fast_eax/eax.cpp`. Instead of clearing the `modifications` vector directly, it now calls the `reset()` method, which likely encapsulates the clearing logic and any other necessary state resets.

* Changed from calling `modifications.clear()` to `reset()` for better encapsulation and possible additional state management in `IntermediateIndividual::convert_to_child_and_revert()` (`src/fast_eax/eax.cpp`).