### PR TITLE
block2戦略をeaxlibに追加

### DIFF
--- a/src/libeaxlib/block2_e_set_assembler.cpp
+++ b/src/libeaxlib/block2_e_set_assembler.cpp
@@ -1,0 +1,146 @@
+#include "block2_e_set_assembler.hpp"
+
+namespace {
+void set_initial_e_set(std::vector<size_t>& e_set,
+                        size_t center_ab_cycle_index,
+                        std::mt19937& rng,
+                        size_t cycle_count,
+                        std::vector<std::vector<size_t>> const& shared_vertex_count,
+                        std::vector<size_t> const& AB_cycle_size) {
+    using namespace std;
+
+    uniform_int_distribution<size_t> dist01(0, 1);
+
+    e_set.clear();
+    e_set.reserve(cycle_count);
+    e_set.push_back(center_ab_cycle_index);
+    for (size_t i = 0; i < cycle_count; ++i) {
+        if (shared_vertex_count[center_ab_cycle_index][i] > 0 &&
+            AB_cycle_size[i] < AB_cycle_size[center_ab_cycle_index]) {
+            if (dist01(rng) == 0) {
+                e_set.push_back(i);
+            }
+        }
+    }
+}
+}
+
+namespace eax {
+
+mpi::ObjectPool<std::vector<size_t>>::pooled_unique_ptr Block2ESetAssembler::operator()(size_t center_ab_cycle_index,
+                                                                        std::mt19937& rng) {
+    using namespace std;
+
+    vector<size_t> const& AB_cycle_size = *AB_cycle_size_ptr;
+    vector<size_t> const& c_vertex_count = *c_vertex_count_ptr;
+    vector<vector<size_t>> const& shared_vertex_count = *shared_vertex_count_ptr;
+    
+    auto best_e_set_ptr = any_size_vector_pool->acquire_unique();
+    vector<size_t>& best_e_set = *best_e_set_ptr;
+    set_initial_e_set(best_e_set, center_ab_cycle_index, rng, cycle_count, shared_vertex_count, AB_cycle_size);
+
+    auto shared_vertex_count_with_e_set_ptr = any_size_vector_pool->acquire_unique();
+    vector<size_t>& shared_vertex_count_with_e_set = *shared_vertex_count_with_e_set_ptr;
+    auto included_in_e_set_ptr = any_size_vector_pool->acquire_unique();
+    vector<size_t>& included_in_e_set = *included_in_e_set_ptr;
+    auto tabu_list_ptr = any_size_vector_pool->acquire_unique();
+    vector<size_t>& tabu_list = *tabu_list_ptr;
+
+    shared_vertex_count_with_e_set.resize(cycle_count, 0);
+    included_in_e_set.resize(cycle_count, false);
+    tabu_list.resize(cycle_count, 0);
+
+    size_t current_num_c = 0;
+    // ABサイクルを追加する関数
+    auto add_cycle = [&c_vertex_count, &shared_vertex_count,
+                        &shared_vertex_count_with_e_set, &included_in_e_set,
+                        &current_num_c, this](size_t cycle_index){
+        current_num_c += c_vertex_count[cycle_index] - 2 * shared_vertex_count_with_e_set[cycle_index];
+        included_in_e_set[cycle_index] = true;
+
+        for (size_t i = 0; i < cycle_count; ++i) {
+            shared_vertex_count_with_e_set[i] += shared_vertex_count[cycle_index][i];
+        }
+    };
+
+    // ABサイクルを削除する関数
+    auto remove_cycle = [&c_vertex_count, &shared_vertex_count,
+                        &shared_vertex_count_with_e_set, &included_in_e_set,
+                        &current_num_c, this](size_t cycle_index) {
+        current_num_c -= c_vertex_count[cycle_index] - 2 * shared_vertex_count_with_e_set[cycle_index];
+        included_in_e_set[cycle_index] = false;
+
+        for (size_t i = 0; i < cycle_count; ++i) {
+            shared_vertex_count_with_e_set[i] -= shared_vertex_count[cycle_index][i];
+        }
+    };
+    
+    for (auto cycle_index : best_e_set) {
+        add_cycle(cycle_index);
+    }
+    size_t best_num_c = current_num_c;
+    
+    uniform_int_distribution<size_t> tabu_dist(1, 10);
+    
+    size_t iteration = 0;
+    size_t last_best_update_iteration = 0;
+    while (true) {
+        ++iteration;
+        
+        size_t min_num_c = numeric_limits<size_t>::max();
+        size_t selected_cycle_index = 0;
+        bool add = false;
+        bool found = false;
+        for (size_t i = 0; i < cycle_count; ++i) {
+            bool is_tabu = tabu_list[i] >= iteration;
+            if (!included_in_e_set[i] && shared_vertex_count_with_e_set[i] > 0) {
+                size_t num_c = current_num_c + c_vertex_count[i] - 2 * shared_vertex_count_with_e_set[i];
+
+                if ((num_c < best_num_c || !is_tabu) && num_c < min_num_c) {
+                    min_num_c = num_c;
+                    selected_cycle_index = i;
+                    add = true;
+                    found = true;
+                }
+            } else if (included_in_e_set[i] && i != center_ab_cycle_index) {
+                size_t num_c = current_num_c - c_vertex_count[i] + 2 * shared_vertex_count_with_e_set[i];
+                
+                if ((num_c < best_num_c || !is_tabu) && num_c < min_num_c) {
+                    min_num_c = num_c;
+                    selected_cycle_index = i;
+                    add = false;
+                    found = true;
+                }
+            }
+            
+        }
+
+        if (found) {
+            if (add) {
+                add_cycle(selected_cycle_index);
+            } else {
+                remove_cycle(selected_cycle_index);
+            }
+            
+            tabu_list[selected_cycle_index] = iteration + tabu_dist(rng);
+            
+            if (current_num_c < best_num_c) { // 最良解が更新された
+                best_num_c = current_num_c;
+                last_best_update_iteration = iteration;
+                best_e_set.clear();
+                for (size_t i = 0; i < cycle_count; ++i) {
+                    if (included_in_e_set[i]) {
+                        best_e_set.push_back(i);
+                    }
+                }
+            }
+        }
+        
+        if (iteration - last_best_update_iteration >= 20) {
+            break;
+        }
+    }
+    
+    return best_e_set_ptr;
+}
+}

--- a/src/libeaxlib/block2_e_set_assembler.hpp
+++ b/src/libeaxlib/block2_e_set_assembler.hpp
@@ -1,0 +1,165 @@
+#pragma once
+
+#include <cstddef>
+#include <vector>
+#include <random>
+
+#include "object_pool.hpp"
+
+#include "eaxdef.hpp"
+#include "object_pools.hpp"
+
+namespace eax {
+class Block2ESetAssembler {
+public:
+    Block2ESetAssembler(size_t city_count,
+                        mpi::ObjectPool<std::vector<size_t>>::pooled_unique_ptr&& AB_cycle_size_ptr,
+                        mpi::ObjectPool<std::vector<size_t>>::pooled_unique_ptr&& c_vertex_count_ptr,
+                        mpi::ObjectPool<std::vector<std::vector<size_t>>>::pooled_unique_ptr&& shared_vertex_count_ptr,
+                        std::shared_ptr<mpi::ObjectPool<std::vector<size_t>>> any_size_vector_pool)
+        : city_count(city_count),
+          cycle_count(AB_cycle_size_ptr->size()),
+          AB_cycle_size_ptr(std::move(AB_cycle_size_ptr)),
+          c_vertex_count_ptr(std::move(c_vertex_count_ptr)),
+          shared_vertex_count_ptr(std::move(shared_vertex_count_ptr)),
+          any_size_vector_pool(std::move(any_size_vector_pool)) {}
+    
+    mpi::ObjectPool<std::vector<size_t>>::pooled_unique_ptr operator()(size_t center_ab_cycle_index,
+                                                                        std::mt19937& rng);
+private:
+    size_t city_count;
+    size_t cycle_count;
+    mpi::ObjectPool<std::vector<size_t>>::pooled_unique_ptr AB_cycle_size_ptr;
+    mpi::ObjectPool<std::vector<size_t>>::pooled_unique_ptr c_vertex_count_ptr;
+    mpi::ObjectPool<std::vector<std::vector<size_t>>>::pooled_unique_ptr shared_vertex_count_ptr;
+    std::shared_ptr<mpi::ObjectPool<std::vector<size_t>>> any_size_vector_pool;
+};
+
+class Block2ESetAssemblerBuilder {
+public:
+    Block2ESetAssemblerBuilder(ObjectPools& object_pools)
+        : vector_of_tsp_size_pool(object_pools.vector_of_tsp_size_pool),
+          any_size_vector_pool(object_pools.any_size_vector_pool),
+          shared_vertex_count_pool(object_pools.any_size_2d_vector_pool) {}
+
+    template <doubly_linked_list_like Individual>
+    Block2ESetAssembler create(const Individual& parent1, const Individual& parent2,
+                               const std::vector<mpi::ObjectPool<ab_cycle_t>::pooled_unique_ptr>& AB_cycles) {
+        using namespace std;
+        
+        size_t city_count = parent1.size();
+        size_t cycle_count = AB_cycles.size();
+
+        auto belongs_to_AB_cycle1_ptr = vector_of_tsp_size_pool->acquire_unique();
+        auto belongs_to_AB_cycle2_ptr = vector_of_tsp_size_pool->acquire_unique();
+        vector<size_t>& belongs_to_AB_cycle1 = *belongs_to_AB_cycle1_ptr;
+        vector<size_t>& belongs_to_AB_cycle2 = *belongs_to_AB_cycle2_ptr;
+        
+        const size_t NULL_CYCLE = std::numeric_limits<size_t>::max();
+        for (size_t i = 0; i < city_count; ++i) {
+            belongs_to_AB_cycle1[i] = NULL_CYCLE;
+            belongs_to_AB_cycle2[i] = NULL_CYCLE;
+        }
+
+        // 各ABサイクルのサイズを記録
+        auto AB_cycle_size_ptr = any_size_vector_pool->acquire_unique();
+        vector<size_t>& AB_cycle_size = *AB_cycle_size_ptr;
+        AB_cycle_size.resize(cycle_count, 0);
+        for (size_t i = 0; i < cycle_count; ++i) {
+            const auto& cycle = *AB_cycles[i];
+            AB_cycle_size[i] = cycle.size();
+        }
+        
+        // 各頂点が属するABサイクルを記録
+        for (size_t i = 0; i < cycle_count; ++i) {
+            const auto& cycle = *AB_cycles[i];
+            for (auto city : cycle) {
+                if (belongs_to_AB_cycle1[city] == NULL_CYCLE) {
+                    belongs_to_AB_cycle1[city] = i;
+                } else if (belongs_to_AB_cycle2[city] == NULL_CYCLE) {
+                    belongs_to_AB_cycle2[city] = i;
+                } else {
+                    throw std::runtime_error("City belongs to more than 2 AB cycles");
+                }
+            }
+        }
+        
+        // 無効ABサイクルを隣接する有効ABサイクルと統合する
+        for (size_t i = 0; i < city_count; ++i) {
+            if (belongs_to_AB_cycle1[i] != NULL_CYCLE && belongs_to_AB_cycle2[i] == NULL_CYCLE) {
+                // AB_cyclesには、すべての有効ABサイクルが含まれているので、
+                // 一方しか記録されていないならば、もう一方は無効ABサイクルである
+                size_t AB_cycle_index = belongs_to_AB_cycle1[i];
+                size_t v1 = i;
+                
+                // 有効ABサイクルに属している方の頂点
+                size_t v_belonging_to_AB_cycle = 0;
+                // 無効ABサイクルは親間で一致している辺で構成されるので
+                // そうではない方を見ればよい
+                if (parent1[v1][0] != parent2[v1][0] && parent1[v1][0] != parent2[v1][1]) {
+                    v_belonging_to_AB_cycle = parent1[v1][0];
+                } else if (parent1[v1][1] != parent2[v1][0] && parent1[v1][1] != parent2[v1][1]) {
+                    v_belonging_to_AB_cycle = parent1[v1][1];
+                } else {
+                    throw std::runtime_error("Invalid AB cycle");
+                }
+                
+                // 無効ABサイクルをたどって、その頂点を有効ABサイクルAB_cycle_indexに追加する
+                while (true) {
+                    belongs_to_AB_cycle2[v1] = AB_cycle_index;
+                    size_t next_v1 = parent1[v1][0];
+                    if (next_v1 == v_belonging_to_AB_cycle) {
+                        next_v1 = parent1[v1][1];
+                    }
+                    
+                    if (belongs_to_AB_cycle1[next_v1] == NULL_CYCLE) {
+                        belongs_to_AB_cycle1[next_v1] = AB_cycle_index;
+                    } else if (belongs_to_AB_cycle2[next_v1] == NULL_CYCLE) {
+                        belongs_to_AB_cycle2[next_v1] = AB_cycle_index;
+                        break; // 無効ABサイクルの系列の終端に到達した
+                    } else {
+                        throw std::runtime_error("Invalid AB cycle");
+                    }
+                    
+                    v_belonging_to_AB_cycle = v1;
+                    v1 = next_v1;
+                }
+            }
+        }
+        
+        // 初期化
+        auto c_vertex_count_ptr = vector_of_tsp_size_pool->acquire_unique();
+        auto& c_vertex_count = *c_vertex_count_ptr;
+        c_vertex_count.resize(cycle_count, 0);
+
+        auto shared_vertex_count_ptr = shared_vertex_count_pool->acquire_unique();
+        auto& shared_vertex_count = *shared_vertex_count_ptr;
+        shared_vertex_count.resize(cycle_count);
+        for (size_t i = 0; i < cycle_count; ++i) {
+            shared_vertex_count[i].resize(cycle_count, 0);
+        }
+        
+        // C頂点の数と共有頂点の数をカウント
+        for (size_t i = 0; i < city_count; ++i) {
+            if (belongs_to_AB_cycle1[i] != belongs_to_AB_cycle2[i]) {
+                ++c_vertex_count[belongs_to_AB_cycle1[i]];
+                ++c_vertex_count[belongs_to_AB_cycle2[i]];
+                if (belongs_to_AB_cycle1[i] != NULL_CYCLE && belongs_to_AB_cycle2[i] != NULL_CYCLE) {
+                    ++shared_vertex_count[belongs_to_AB_cycle1[i]][belongs_to_AB_cycle2[i]];
+                    ++shared_vertex_count[belongs_to_AB_cycle2[i]][belongs_to_AB_cycle1[i]];
+                }
+            }
+        }
+        
+        return Block2ESetAssembler(city_count,
+                                  std::move(AB_cycle_size_ptr),
+                                  std::move(c_vertex_count_ptr),
+                                  std::move(shared_vertex_count_ptr),
+                                  any_size_vector_pool);
+    }
+private:
+    std::shared_ptr<mpi::ObjectPool<std::vector<size_t>>> vector_of_tsp_size_pool;
+    std::shared_ptr<mpi::ObjectPool<std::vector<size_t>>> any_size_vector_pool;
+    std::shared_ptr<mpi::ObjectPool<std::vector<std::vector<size_t>>>> shared_vertex_count_pool;
+};
+}

--- a/src/libeaxlib/eax_block2.hpp
+++ b/src/libeaxlib/eax_block2.hpp
@@ -1,0 +1,118 @@
+#pragma once
+
+#include <vector>
+#include <memory>
+#include <random>
+
+#include "eaxdef.hpp"
+#include "object_pools.hpp"
+#include "crossover_delta.hpp"
+#include "tsp_loader.hpp"
+#include "ab_cycle_finder.hpp"
+#include "block2_e_set_assembler.hpp"
+#include "subtour_merger.hpp"
+
+namespace eax {
+class EAX_Block2 {
+public:
+    EAX_Block2(ObjectPools& object_pools)
+        : vector_of_tsp_size_pool(object_pools.vector_of_tsp_size_pool),
+          any_size_vector_pool(object_pools.any_size_vector_pool),
+          intermediate_individual_pool(object_pools.intermediate_individual_pool),
+          ab_cycle_finder(std::make_shared<ABCycleFinder>(object_pools)),
+          block2_e_set_assembler_builder(std::make_shared<Block2ESetAssemblerBuilder>(object_pools)),
+          subtour_merger(std::make_shared<SubtourMerger>(object_pools)) {}
+
+    template <doubly_linked_list_like Individual>
+    std::vector<CrossoverDelta> operator()(const Individual& parent1, const Individual& parent2, size_t children_size,
+                                        const tsp::TSP& tsp, std::mt19937& rng) {
+        auto& adjacency_matrix = tsp.adjacency_matrix;
+        using namespace std;
+
+        const size_t n = parent1.size();
+
+        auto path_ptr = vector_of_tsp_size_pool->acquire_unique();
+        auto pos_ptr = vector_of_tsp_size_pool->acquire_unique();
+        vector<size_t>& path = *path_ptr;
+        vector<size_t>& pos = *pos_ptr;
+        
+        // 親間で異なる枝の本数
+        size_t different_edges_count = 0;
+        for (size_t i = 0, prev = 0, current = 0; i < n; ++i) {
+            path[i] = current;
+            pos[current] = i;
+            size_t next = parent1[current][0];
+            if (next == prev) {
+                next = parent1[current][1];
+            }
+            
+            if (parent2[current][0] != next && parent2[current][1] != next)
+                ++different_edges_count;
+            prev = current;
+            current = next;
+        }
+
+        auto AB_cycles = (*ab_cycle_finder)(numeric_limits<size_t>::max(), parent1, parent2, rng);
+        
+        sort(AB_cycles.begin(), AB_cycles.end(), [](const mpi::ObjectPool<vector<size_t>>::pooled_unique_ptr& a, const mpi::ObjectPool<vector<size_t>>::pooled_unique_ptr& b) {
+            return a->size() > b->size();
+        });
+        
+        // Block2Strategy block2_strategy(parent1, parent2, AB_cycles, n, env.object_pools.vector_of_tsp_size_pool, env.object_pools.any_size_vector_pool, env.object_pools.any_size_2d_vector_pool);
+        auto block2_e_set_assembler = block2_e_set_assembler_builder->create(parent1, parent2, AB_cycles);
+        
+        children_size = min(children_size, AB_cycles.size());
+
+        vector<CrossoverDelta> children;
+        auto working_individual = intermediate_individual_pool->acquire_unique();
+        working_individual->assign(parent1);
+        for (size_t child_index = 0; child_index < children_size; ++child_index) {
+            // auto selected_AB_cycles_indices_ptr = block2_strategy.search_e_set_with_tabu_search(child_index, env.object_pools.any_size_vector_pool, rng);
+            auto selected_AB_cycles_indices_ptr = block2_e_set_assembler(child_index, rng);
+            auto& selected_AB_cycles_indices = *selected_AB_cycles_indices_ptr;
+            
+            if (selected_AB_cycles_indices.size() == AB_cycles.size()) {
+                continue; // 全てのABサイクルを選択している場合はスキップ
+            }
+            
+            auto selected_AB_cycles_view = selected_AB_cycles_indices | views::transform([&AB_cycles](size_t index) -> const ab_cycle_t& {
+                return *AB_cycles[index];
+            });
+
+            working_individual->apply_AB_cycles(selected_AB_cycles_view);
+
+            // merge_sub_tours(adjacency_matrix, *working_individual, path, pos, NN_list, env);
+            (*subtour_merger)(*working_individual, tsp, selected_AB_cycles_view);
+            
+            // 削除された親1の枝の数(追加された親２の枝の数)
+            size_t swapped_edges_count = 0;
+            for (size_t i = 0; i < selected_AB_cycles_indices.size(); ++i) {
+                const auto& cycle = *AB_cycles[selected_AB_cycles_indices[i]];
+                swapped_edges_count += cycle.size() / 2;
+            }
+            
+            if (swapped_edges_count * 2 >= different_edges_count &&
+                parent1.get_distance() + working_individual->calc_delta_distance(adjacency_matrix) == parent2.get_distance()) {
+                // 交換された枝の数が親間で異なる枝の数の半分以上であり、
+                // 子供の距離が親2と同じ場合は、子供を追加しない
+                working_individual->discard();
+                continue;
+            }
+
+            children.emplace_back(working_individual->get_delta_and_revert());
+        }
+        
+        if (children.empty()) {
+            children.emplace_back(working_individual->get_delta_and_revert());
+        }
+        return children;
+    }
+private:
+    std::shared_ptr<mpi::ObjectPool<std::vector<size_t>>> vector_of_tsp_size_pool;
+    std::shared_ptr<mpi::ObjectPool<std::vector<size_t>>> any_size_vector_pool;
+    std::shared_ptr<mpi::ObjectPool<IntermediateIndividual>> intermediate_individual_pool;
+    std::shared_ptr<ABCycleFinder> ab_cycle_finder;
+    std::shared_ptr<Block2ESetAssemblerBuilder> block2_e_set_assembler_builder;
+    std::shared_ptr<SubtourMerger> subtour_merger;
+};
+}

--- a/src/libeaxlib/object_pools.hpp
+++ b/src/libeaxlib/object_pools.hpp
@@ -23,6 +23,7 @@ struct ObjectPools {
     std::shared_ptr<mpi::ObjectPool<std::vector<uint8_t>>> in_min_sub_tour_pool;
     std::shared_ptr<mpi::ObjectPool<std::vector<std::tuple<size_t, size_t, size_t>>>> cut_positions_pool;
     std::shared_ptr<mpi::ObjectPool<SubtourList>> subtour_list_pool;
+    std::shared_ptr<mpi::ObjectPool<std::vector<std::vector<size_t>>>> any_size_2d_vector_pool;
     
     ObjectPools(size_t city_size)
         : vector_of_tsp_size_pool(std::make_shared<mpi::ObjectPool<std::vector<size_t>>>([city_size]() {
@@ -48,6 +49,9 @@ struct ObjectPools {
         })),
           subtour_list_pool(std::make_shared<mpi::ObjectPool<SubtourList>>([]() {
             return new SubtourList();
+        })),
+          any_size_2d_vector_pool(std::make_shared<mpi::ObjectPool<std::vector<std::vector<size_t>>>>([]() {
+            return new std::vector<std::vector<size_t>>();
         })) {}
 };
 }


### PR DESCRIPTION
This pull request introduces a new implementation of the Block2 strategy for EAX crossover in the TSP solver, focusing on assembling sets of AB cycles using a tabu search approach. The changes add new classes for assembling AB cycle sets, update object pool management to support the new algorithm, and implement the main Block2 crossover logic.

### Block2 EAX crossover implementation

* Added `Block2ESetAssembler` and `Block2ESetAssemblerBuilder` classes in `block2_e_set_assembler.cpp` and `block2_e_set_assembler.hpp`, which construct sets of AB cycles using a tabu search, including logic for initializing, updating, and tracking cycles and shared vertices. [[1]](diffhunk://#diff-8cfa9a51444285df0e6e0bf97959c153897d6977d96e8afde15fc0f2c1e7e714R1-R146) [[2]](diffhunk://#diff-21893e01f736309458be8fa756d2b38099de3e6bc6045b846695ace3c7f1ff74R1-R165)
* Added `EAX_Block2` class in `eax_block2.hpp`, implementing the Block2 crossover strategy, integrating AB cycle finding, Block2 set assembling, and subtour merging, and returning crossover results.

### Object pool and resource management

* Extended `ObjectPools` with a new `any_size_2d_vector_pool` for pooling 2D vectors needed in the Block2 algorithm. [[1]](diffhunk://#diff-5531e0fe2a75162608083ddfc7834cdcf014568640b42680d4da8a8547d26c85R26) [[2]](diffhunk://#diff-5531e0fe2a75162608083ddfc7834cdcf014568640b42680d4da8a8547d26c85R52-R54)

These changes collectively add a new, more sophisticated Block2 crossover mechanism to the library, improving the flexibility and performance of EAX-based recombination.