### PR TITLE
feat: 記述を容易にするために、pooled_unique_ptrとpooled_ptrのエイリアスを追加

### DIFF
--- a/src/libmpilib/object_pool.hpp
+++ b/src/libmpilib/object_pool.hpp
@@ -76,4 +76,10 @@ namespace mpi {
         std::function<T*()> factory;
         std::shared_ptr<std::vector<std::unique_ptr<T>>> pool;
     };
+    
+    template <typename T>
+    using pooled_unique_ptr = typename ObjectPool<T>::pooled_unique_ptr;
+
+    template <typename T>
+    using pooled_ptr = typename ObjectPool<T>::pooled_ptr;
 }


### PR DESCRIPTION
This pull request introduces new type aliases to simplify usage of pooled pointers in the `mpi` namespace. These changes make it easier to refer to pooled pointer types outside of the `ObjectPool` class.

Type alias additions:

* Added `pooled_unique_ptr` and `pooled_ptr` type aliases to the `mpi` namespace, allowing direct usage of these pooled pointer types without needing to reference them through `ObjectPool`.