### PR TITLE
Feat/improve object pool

### DIFF
--- a/src/libmpilib/object_pool.hpp
+++ b/src/libmpilib/object_pool.hpp
@@ -54,6 +54,9 @@ namespace mpi {
         
         ObjectPool(const ObjectPool&) = delete; // コピーコンストラクタは削除
         ObjectPool& operator=(const ObjectPool&) = delete; // コピー代入演算子は削除
+
+        ObjectPool(ObjectPool&&) noexcept = default; // ムーブコンストラクタはデフォルト
+        ObjectPool& operator=(ObjectPool&&) noexcept = default; // ムーブ代入演算子はデフォルト
         
     private:
         class ObjectDeleter {

--- a/src/libmpilib/object_pool.hpp
+++ b/src/libmpilib/object_pool.hpp
@@ -58,6 +58,10 @@ namespace mpi {
         ObjectPool(ObjectPool&&) noexcept = default; // ムーブコンストラクタはデフォルト
         ObjectPool& operator=(ObjectPool&&) noexcept = default; // ムーブ代入演算子はデフォルト
         
+        ObjectPool share() const {
+            return ObjectPool(*this, shallow_copy_tag{});
+        }
+
     private:
         class ObjectDeleter {
         public:
@@ -75,6 +79,10 @@ namespace mpi {
             
             friend class ObjectPool;
         };
+        
+        struct shallow_copy_tag {};
+        ObjectPool(const ObjectPool& other, shallow_copy_tag)
+            : factory(other.factory), pool(other.pool) {}
 
         std::function<T*()> factory;
         std::shared_ptr<std::vector<std::unique_ptr<T>>> pool;


### PR DESCRIPTION
This pull request enhances the `ObjectPool` class in `src/libmpilib/object_pool.hpp` to support move semantics and introduces a mechanism for shallow copying. These changes improve the flexibility and usability of the object pool, making it easier to share resources and work with modern C++ features.

**Move semantics support:**

* Added a default move constructor and move assignment operator to `ObjectPool`, allowing instances to be efficiently moved.

**Shallow copy functionality:**

* Introduced a `share()` method to create a shallow copy of an `ObjectPool`, enabling shared access to the underlying pool.
* Added a `shallow_copy_tag` struct and a corresponding constructor to implement shallow copying logic.