### PR TITLE
距離保存評価器の実装を追加

### DIFF
--- a/src/libeaxlib/distance_preserving_evaluator.hpp
+++ b/src/libeaxlib/distance_preserving_evaluator.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "eaxdef.hpp"
+#include "crossover_delta.hpp"
+
+namespace eax {
+namespace eval {
+namespace delta {
+    struct DistancePreserving {
+        double operator()(const CrossoverDelta& child, const adjacency_matrix_t& adjacency_matrix, edge_counts_t& pop_edge_counts, double epsilon = 1e-9) const {
+            double delta_L = child.get_delta_distance(adjacency_matrix);
+            
+            if (delta_L >= 0.0) {
+                return -1.0;
+            }
+
+            double delta_H = 0;
+            
+            for (const auto& modification : child.get_modifications()) {
+                auto [v1, v2] = modification.edge1;
+                size_t new_v2 = modification.new_v2;
+                
+                delta_H -= pop_edge_counts[v1][v2] - 1;
+                --pop_edge_counts[v1][v2];
+
+                delta_H += pop_edge_counts[v1][new_v2];
+                ++pop_edge_counts[v1][new_v2];
+            }
+            
+            for (const auto& modification : child.get_modifications()) {
+                auto [v1, v2] = modification.edge1;
+                size_t new_v2 = modification.new_v2;
+                
+                ++pop_edge_counts[v1][v2];
+                --pop_edge_counts[v1][new_v2];
+            }
+
+            // 多様性が増すならば
+            if (delta_H >= 0) {
+                return -1.0 * delta_L / epsilon;
+            }
+
+            // 多様性が減るならば
+            // 減少多様性当たりの距離の減少量を評価値とする
+            return delta_L / delta_H;
+        }
+    };
+}
+} // namespace eval
+} // namespace eax


### PR DESCRIPTION
This pull request introduces a new distance-preserving evaluator to the codebase. The main addition is the `DistancePreserving` struct, which defines an operator for evaluating crossover deltas in terms of both distance and diversity preservation.

New distance-preserving evaluation logic:

* Added the `DistancePreserving` struct in `src/libeaxlib/distance_preserving_evaluator.hpp`, implementing a custom operator() that evaluates a `CrossoverDelta` by considering both the change in distance and the impact on edge diversity, with logic to penalize or reward based on diversity changes.