### PR TITLE
build: CXXFLAGSに既存のフラグを追加するように修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ MAKEFILE_TEMPLATE_FOR_APP=makefiles/Makefile_app.mk
 MAKEFILE_TEMPLATE_FOR_LIB=makefiles/Makefile_lib.mk
 
 export ROOT_DIR=$(shell pwd)
-export CXXFLAGS=-std=c++23 -O3 -Wall -Wextra -pedantic -mtune=native -march=native -flto
+export CXXFLAGS:=-std=c++23 -O3 -Wall -Wextra -pedantic -mtune=native -march=native -flto $(CXXFLAGS)
 
 all: $(APP_TARGETS) $(LIB_TARGETS)
 


### PR DESCRIPTION
This pull request makes a minor update to the `Makefile` to improve the handling of the `CXXFLAGS` variable.

* Build configuration: Changed the export of `CXXFLAGS` to use the `:=` assignment and append any existing `CXXFLAGS`, allowing users to override or extend compiler flags more easily.