### PR TITLE
部分巡回路のサイズが正しく計算されない問題を修正

### DIFF
--- a/src/libeaxlib/subtour_finder.cpp
+++ b/src/libeaxlib/subtour_finder.cpp
@@ -92,7 +92,7 @@ void SubtourFinder::calc_sub_tour_sizes_and_merge_redundant_segments(eax::Subtou
         } else {
             ++forcused_segment_id;
             segments[forcused_segment_id] = segment;
-            sub_tour_sizes[segment.sub_tour_ID] = segment.end_pos - segment.beginning_pos + 1;
+            sub_tour_sizes[segment.sub_tour_ID] += segment.end_pos - segment.beginning_pos + 1;
         }
     }
     segments.resize(forcused_segment_id + 1);


### PR DESCRIPTION
This pull request makes a targeted fix to the calculation of sub-tour sizes in the `SubtourFinder` class. The change ensures that the sizes of sub-tours are accumulated correctly when segments are merged, rather than being overwritten.

Bug fix for sub-tour size calculation:

* Updated the assignment to `sub_tour_sizes[segment.sub_tour_ID]` in `SubtourFinder::calc_sub_tour_sizes_and_merge_redundant_segments` to accumulate the segment size instead of overwriting it, ensuring correct sub-tour size calculation when merging redundant segments.