### PR TITLE
assignを用いるべきところがresizeになっていた問題を修正

### DIFF
--- a/src/eax_tabu/context.cpp
+++ b/src/eax_tabu/context.cpp
@@ -131,7 +131,7 @@ Context Context::deserialize(std::istream& is, tsp::TSP tsp) {
     read_val("# GA State");
     // ## Population Edge Counts
     read_val("## Population Edge Counts");
-    context.pop_edge_counts.resize(context.env.tsp.city_count, std::vector<size_t>(context.env.tsp.city_count, 0));
+    context.pop_edge_counts.assign(context.env.tsp.city_count, std::vector<size_t>(context.env.tsp.city_count, 0));
     for (size_t i = 0; i < context.env.tsp.city_count; ++i) {
         std::getline(is, line);
         std::istringstream iss(line);

--- a/src/eax_tabu/context.hpp
+++ b/src/eax_tabu/context.hpp
@@ -54,7 +54,7 @@ namespace eax {
         double elapsed_time = 0.0;
 
         void set_initial_edge_counts(const std::vector<Individual>& init_pop) {
-            pop_edge_counts.resize(env.tsp.city_count, std::vector<size_t>(env.tsp.city_count, 0));
+            pop_edge_counts.assign(env.tsp.city_count, std::vector<size_t>(env.tsp.city_count, 0));
             
             for (const auto& individual : init_pop) {
                 for (size_t i = 0; i < individual.size(); ++i) {

--- a/src/libeaxlib/block2_e_set_assembler.cpp
+++ b/src/libeaxlib/block2_e_set_assembler.cpp
@@ -46,9 +46,9 @@ mpi::pooled_unique_ptr<std::vector<size_t>> Block2ESetAssembler::operator()(size
     auto tabu_list_ptr = any_size_vector_pool.acquire_unique();
     vector<size_t>& tabu_list = *tabu_list_ptr;
 
-    shared_vertex_count_with_e_set.resize(cycle_count, 0);
-    included_in_e_set.resize(cycle_count, false);
-    tabu_list.resize(cycle_count, 0);
+    shared_vertex_count_with_e_set.assign(cycle_count, 0);
+    included_in_e_set.assign(cycle_count, false);
+    tabu_list.assign(cycle_count, 0);
 
     size_t current_num_c = 0;
     // ABサイクルを追加する関数

--- a/src/libeaxlib/block2_e_set_assembler.hpp
+++ b/src/libeaxlib/block2_e_set_assembler.hpp
@@ -64,7 +64,7 @@ public:
         // 各ABサイクルのサイズを記録
         auto AB_cycle_size_ptr = any_size_vector_pool.acquire_unique();
         vector<size_t>& AB_cycle_size = *AB_cycle_size_ptr;
-        AB_cycle_size.resize(cycle_count, 0);
+        AB_cycle_size.resize(cycle_count);
         for (size_t i = 0; i < cycle_count; ++i) {
             const auto& cycle = *AB_cycles[i];
             AB_cycle_size[i] = cycle.size();
@@ -130,13 +130,13 @@ public:
         // 初期化
         auto c_vertex_count_ptr = vector_of_tsp_size_pool.acquire_unique();
         auto& c_vertex_count = *c_vertex_count_ptr;
-        c_vertex_count.resize(cycle_count, 0);
+        c_vertex_count.assign(cycle_count, 0);
 
         auto shared_vertex_count_ptr = shared_vertex_count_pool.acquire_unique();
         auto& shared_vertex_count = *shared_vertex_count_ptr;
         shared_vertex_count.resize(cycle_count);
         for (size_t i = 0; i < cycle_count; ++i) {
-            shared_vertex_count[i].resize(cycle_count, 0);
+            shared_vertex_count[i].assign(cycle_count, 0);
         }
         
         // C頂点の数と共有頂点の数をカウント

--- a/src/libeaxlib/subtour_finder.cpp
+++ b/src/libeaxlib/subtour_finder.cpp
@@ -81,7 +81,7 @@ void SubtourFinder::calc_sub_tour_sizes_and_merge_redundant_segments(eax::Subtou
     auto& segments = subtour_list.segments;
     auto& sub_tour_sizes = subtour_list.sub_tour_sizes;
 
-    sub_tour_sizes.resize(sub_tour_count, 0);
+    sub_tour_sizes.assign(sub_tour_count, 0);
 
     size_t forcused_segment_id = 0;
     for (const auto& segment : segments) {

--- a/src/normal_eax/context.cpp
+++ b/src/normal_eax/context.cpp
@@ -134,7 +134,7 @@ Context Context::deserialize(std::istream& is, tsp::TSP tsp) {
     }
     // ## Population Edge Counts
     read_val("## Population Edge Counts");
-    context.pop_edge_counts.resize(context.env.tsp.city_count, std::vector<size_t>(context.env.tsp.city_count, 0));
+    context.pop_edge_counts.assign(context.env.tsp.city_count, std::vector<size_t>(context.env.tsp.city_count, 0));
     for (size_t i = 0; i < context.env.tsp.city_count; ++i) {
         std::getline(is, line);
         std::istringstream iss(line);

--- a/src/normal_eax/context.hpp
+++ b/src/normal_eax/context.hpp
@@ -65,7 +65,7 @@ namespace eax {
         double elapsed_time = 0.0;
 
         void set_initial_edge_counts(const std::vector<Individual>& init_pop) {
-            pop_edge_counts.resize(env.tsp.city_count, std::vector<size_t>(env.tsp.city_count, 0));
+            pop_edge_counts.assign(env.tsp.city_count, std::vector<size_t>(env.tsp.city_count, 0));
             
             for (const auto& individual : init_pop) {
                 for (size_t i = 0; i < individual.size(); ++i) {


### PR DESCRIPTION
This pull request focuses on improving memory initialization practices across several files by replacing `resize` with `assign` when initializing or resetting vectors. This change ensures that vectors are properly cleared and re-initialized with the intended values, reducing the risk of unintended data retention and potential bugs. Additionally, there is a minor adjustment to how a vector is resized without default values in one location.

**Vector initialization improvements:**

* Replaced `resize(..., value)` with `assign(..., value)` for 1D and 2D vectors in multiple locations to ensure vectors are cleared and filled with the correct default values:
  - `pop_edge_counts` in both `src/eax_tabu/context.cpp` and `src/normal_eax/context.cpp` during deserialization (`[[1]](diffhunk://#diff-fa7c11785b549b00d71239185ecf6104cf6bc0fbafd2607de8b05e6264b87340L134-R134)`, `[[2]](diffhunk://#diff-a54ea9d1804027c57c232d4c5cb12f5370cef26bf409034d8e1e9983f93fe3baL137-R137)`)
  - `pop_edge_counts` in the `set_initial_edge_counts` method in both `src/eax_tabu/context.hpp` and `src/normal_eax/context.hpp` (`[[1]](diffhunk://#diff-7327c745a1aa2adca76bd3aecf7faf0ce1e14b52efc566df9603f3e7b4a53f0fL57-R57)`, `[[2]](diffhunk://#diff-d5c6085646b8d27e55a96aa64f3463879c5b6c4496e7434ccc9f170f76b8898fL68-R68)`)
  - Several vectors in `Block2ESetAssembler::operator()` in `src/libeaxlib/block2_e_set_assembler.cpp` (`[src/libeaxlib/block2_e_set_assembler.cppL49-R51](diffhunk://#diff-8cfa9a51444285df0e6e0bf97959c153897d6977d96e8afde15fc0f2c1e7e714L49-R51)`)
  - `c_vertex_count` and `shared_vertex_count` in `Block2ESetAssemblerBuilder` in `src/libeaxlib/block2_e_set_assembler.hpp` (`[src/libeaxlib/block2_e_set_assembler.hppL133-R139](diffhunk://#diff-21893e01f736309458be8fa756d2b38099de3e6bc6045b846695ace3c7f1ff74L133-R139)`)
  - `sub_tour_sizes` in `SubtourFinder::calc_sub_tour_sizes_and_merge_redundant_segments` in `src/libeaxlib/subtour_finder.cpp` (`[src/libeaxlib/subtour_finder.cppL84-R84](diffhunk://#diff-87490b9d886e93a5f7d063b0108462e737bcf3ad2f6521cf68b5b9e90a171673L84-R84)`)

**Minor vector resizing adjustment:**

* Changed `AB_cycle_size.resize(cycle_count, 0)` to `AB_cycle_size.resize(cycle_count)` in `Block2ESetAssemblerBuilder` to remove unnecessary default value initialization, likely because the vector will be filled immediately after resizing (`[src/libeaxlib/block2_e_set_assembler.hppL67-R67](diffhunk://#diff-21893e01f736309458be8fa756d2b38099de3e6bc6045b846695ace3c7f1ff74L67-R67)`).