### PR TITLE
delta_Hの計算を修正し、正しい評価値を返すように変更

### DIFF
--- a/src/libeaxlib/distance_preserving_evaluator.hpp
+++ b/src/libeaxlib/distance_preserving_evaluator.hpp
@@ -34,6 +34,8 @@ namespace delta {
                 ++pop_edge_counts[v1][v2];
                 --pop_edge_counts[v1][new_v2];
             }
+            
+            delta_H *= -1.0;
 
             // 多様性が増すならば
             if (delta_H >= 0) {


### PR DESCRIPTION
This pull request makes a minor update to the distance-preserving evaluator logic. The change negates the value of `delta_H` before it is used in a conditional check, which may affect the behavior of the diversity evaluation.

* Negated the `delta_H` value before the diversity increase check in the `distance_preserving_evaluator.hpp` file to potentially correct or adjust the evaluation logic.